### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python minesweeper_primative.py"

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Python-based Minesweeper api and primative game.
 
 Have pip3 installed, run depend.sh, then run minesweeper_primative.py in the same directory as the api.
+
+[![Run on Repl.it](https://repl.it/badge/github/HopefulFire/minesweeper)](https://repl.it/github/HopefulFire/minesweeper)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@JadeMasker/minesweeper-1).